### PR TITLE
rosapi hotdog python3

### DIFF
--- a/rosapi/scripts/rosapi_node
+++ b/rosapi/scripts/rosapi_node
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2012, Willow Garage, Inc.


### PR DESCRIPTION
My understading is that Hotdog should be exclusively Python3. The rosapi node is launched during Vector bringup, and as far as I've been able to test, the simple change proposed here is sufficient. Please DO NOT MERGE this, this is only meant to start a conversation, but further analysis is needed.